### PR TITLE
Fix #override bug

### DIFF
--- a/lib/dim.rb
+++ b/lib/dim.rb
@@ -58,9 +58,14 @@ module Dim
     # create the service on demand.  It is recommended that symbols be
     # used as the name of a service.
     def register(name,raise_error_on_duplicate = true,&block)
-      if @services[name] && raise_error_on_duplicate
-        fail DuplicateServiceError, "Duplicate Service Name '#{name}'"
+      if @services[name]
+        if raise_error_on_duplicate
+          fail DuplicateServiceError, "Duplicate Service Name '#{name}'"
+        else # delete the service from the cache
+          @cache.delete(name)
+        end
       end
+
       @services[name] = block
 
       self.class.send(:define_method, name) do

--- a/spec/dim_spec.rb
+++ b/spec/dim_spec.rb
@@ -45,6 +45,13 @@ describe Dim::Container do
     Then { container.some_value.should == "B" }
   end
 
+  Scenario "overriding previously-registered objects" do
+    Given { container.register(:some_value) { "A" } }
+    Given { container.some_value == "A" }
+    Given { container.override(:some_value) { "B" } }
+    Then { container.some_value.should == "B" }
+  end
+
   it "clears cache explicitly" do
     container.register(:app) { App.new }
     app_before = container.app

--- a/spec/dim_spec.rb
+++ b/spec/dim_spec.rb
@@ -45,7 +45,7 @@ describe Dim::Container do
     Then { container.some_value.should == "B" }
   end
 
-  Scenario "overriding previously-registered objects" do
+  Scenario "overriding previously-registered objects after calling" do
     Given { container.register(:some_value) { "A" } }
     Given { container.some_value == "A" }
     Given { container.override(:some_value) { "B" } }

--- a/spec/dim_spec.rb
+++ b/spec/dim_spec.rb
@@ -147,7 +147,7 @@ describe Dim::Container do
     end
 
     Scenario "overiding a service from the parent" do
-      Then "the child service overrides the parent" do
+      Then do # the child service overrides the parent
         child.gene.should == :child_gene
       end
     end


### PR DESCRIPTION
This PR fixes the following:
- A defect in the current rspecs
- A defect in Dim::Container#override - When a service is registered and then called, #override does not have the appropriate behavior because the old value is cached.

The invalid caching behavior would also be exhibited when calling #register with raise_error_on_duplicate set to false.  This PR resolves that behavior as well.
